### PR TITLE
Avoid potential cache collisions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
     <groupId>pl.net.was</groupId>
     <artifactId>trino-git</artifactId>
-    <version>0.66-SNAPSHOT</version>
+    <version>0.66</version>
     <packaging>trino-plugin</packaging>
     <description>Trino git Connector</description>
 
@@ -24,7 +24,7 @@
 
     <scm>
         <developerConnection>scm:git:https://github.com/nineinchnick/trino-git.git</developerConnection>
-        <tag>HEAD</tag>
+        <tag>v0.66</tag>
     </scm>
 
     <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
     <groupId>pl.net.was</groupId>
     <artifactId>trino-git</artifactId>
-    <version>0.67</version>
+    <version>0.68-SNAPSHOT</version>
     <packaging>trino-plugin</packaging>
     <description>Trino git Connector</description>
 
@@ -24,7 +24,7 @@
 
     <scm>
         <developerConnection>scm:git:https://github.com/nineinchnick/trino-git.git</developerConnection>
-        <tag>v0.67</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
     <groupId>pl.net.was</groupId>
     <artifactId>trino-git</artifactId>
-    <version>0.66</version>
+    <version>0.67-SNAPSHOT</version>
     <packaging>trino-plugin</packaging>
     <description>Trino git Connector</description>
 
@@ -24,7 +24,7 @@
 
     <scm>
         <developerConnection>scm:git:https://github.com/nineinchnick/trino-git.git</developerConnection>
-        <tag>v0.66</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
     <groupId>pl.net.was</groupId>
     <artifactId>trino-git</artifactId>
-    <version>0.67-SNAPSHOT</version>
+    <version>0.67</version>
     <packaging>trino-plugin</packaging>
     <description>Trino git Connector</description>
 
@@ -24,7 +24,7 @@
 
     <scm>
         <developerConnection>scm:git:https://github.com/nineinchnick/trino-git.git</developerConnection>
-        <tag>HEAD</tag>
+        <tag>v0.67</tag>
     </scm>
 
     <distributionManagement>

--- a/src/main/java/pl/net/was/trino/git/BranchesRecordCursor.java
+++ b/src/main/java/pl/net/was/trino/git/BranchesRecordCursor.java
@@ -27,7 +27,6 @@ import org.eclipse.jgit.revwalk.RevWalk;
 import java.io.IOException;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Optional;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
@@ -46,7 +45,7 @@ public class BranchesRecordCursor
 
     private List<String> fields;
 
-    public BranchesRecordCursor(List<GitColumnHandle> columnHandles, Git repo, Optional<List<String>> commitIds)
+    public BranchesRecordCursor(List<GitColumnHandle> columnHandles, Git repo)
     {
         this.columnHandles = columnHandles;
 

--- a/src/main/java/pl/net/was/trino/git/GitClient.java
+++ b/src/main/java/pl/net/was/trino/git/GitClient.java
@@ -84,7 +84,8 @@ public class GitClient
                     new GitColumn("deleted_lines", IntegerType.INTEGER)),
             Table.tags.name(), List.of(
                     new GitColumn("object_id", VarcharType.VARCHAR),
-                    new GitColumn("name", VarcharType.VARCHAR)),
+                    new GitColumn("name", VarcharType.VARCHAR),
+                    new GitColumn("tag_time", TimestampWithTimeZoneType.TIMESTAMP_TZ_SECONDS)),
             Table.trees.name(), List.of(
                     new GitColumn(TreesColumns.commit_id.name(), VarcharType.VARCHAR),
                     new GitColumn("object_type", VarcharType.VARCHAR),

--- a/src/main/java/pl/net/was/trino/git/GitMetadata.java
+++ b/src/main/java/pl/net/was/trino/git/GitMetadata.java
@@ -63,7 +63,7 @@ public class GitMetadata
         implements ConnectorMetadata
 {
     private final GitClient gitClient;
-    private String catalogName;
+    private final String catalogName;
 
     @Inject
     public GitMetadata(@CatalogName String catalogName, GitClient gitClient)

--- a/src/main/java/pl/net/was/trino/git/GitRecordSet.java
+++ b/src/main/java/pl/net/was/trino/git/GitRecordSet.java
@@ -77,11 +77,11 @@ public class GitRecordSet
     public RecordCursor cursor()
     {
         Map<String, RecordCursorProvider> map = Map.of(
-                "branches", BranchesRecordCursor::new,
+                "branches", (columnHandles, repo, commitIds) -> new BranchesRecordCursor(columnHandles, repo),
                 "commits", CommitsRecordCursor::new,
                 "diff_stats", DiffStatsRecordCursor::new,
-                "objects", ObjectsRecordCursor::new,
-                "tags", TagsRecordCursor::new,
+                "objects", (columnHandles, repo, commitIds) -> new ObjectsRecordCursor(columnHandles, repo),
+                "tags", (columnHandles, repo, commitIds) -> new TagsRecordCursor(columnHandles, repo),
                 "trees", TreesRecordCursor::new);
         RecordCursorProvider recordCursorProvider = map.get(tableName);
         if (recordCursorProvider == null) {

--- a/src/main/java/pl/net/was/trino/git/GitRecordSet.java
+++ b/src/main/java/pl/net/was/trino/git/GitRecordSet.java
@@ -41,7 +41,7 @@ public class GitRecordSet
     private final List<GitColumnHandle> columnHandles;
     private final List<Type> columnTypes;
     private final String tableName;
-    private Git repo;
+    private final Git repo;
     private final Optional<List<String>> commitIds;
 
     public GitRecordSet(GitSplit split, GitTableHandle table, List<GitColumnHandle> columnHandles)

--- a/src/main/java/pl/net/was/trino/git/GitRecordSet.java
+++ b/src/main/java/pl/net/was/trino/git/GitRecordSet.java
@@ -14,6 +14,7 @@
 package pl.net.was.trino.git;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.hash.Hashing;
 import io.trino.spi.connector.RecordCursor;
 import io.trino.spi.connector.RecordSet;
 import io.trino.spi.type.Type;
@@ -33,6 +34,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Objects.requireNonNull;
 
 public class GitRecordSet
@@ -155,6 +157,6 @@ public class GitRecordSet
             }
         }
 
-        return new File(tmpDir, Integer.toHexString(prefix.hashCode()));
+        return new File(tmpDir, Hashing.sha256().hashString(prefix, UTF_8).toString());
     }
 }

--- a/src/main/java/pl/net/was/trino/git/ObjectsRecordCursor.java
+++ b/src/main/java/pl/net/was/trino/git/ObjectsRecordCursor.java
@@ -30,7 +30,6 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.function.Function;
 
 import static com.google.common.base.Preconditions.checkArgument;
@@ -49,7 +48,7 @@ public class ObjectsRecordCursor
 
     private final Map<Integer, Function<ObjectsRecordCursor, Slice>> strFieldGetters = new HashMap<>();
 
-    public ObjectsRecordCursor(List<GitColumnHandle> columnHandles, Git repo, Optional<List<String>> commitIds)
+    public ObjectsRecordCursor(List<GitColumnHandle> columnHandles, Git repo)
     {
         this.columnHandles = columnHandles;
 

--- a/src/main/java/pl/net/was/trino/git/RecordCursorProvider.java
+++ b/src/main/java/pl/net/was/trino/git/RecordCursorProvider.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package pl.net.was.trino.git;
+
+import io.trino.spi.connector.RecordCursor;
+import org.eclipse.jgit.api.Git;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface RecordCursorProvider
+{
+    RecordCursor create(List<GitColumnHandle> columnHandles, Git repo, Optional<List<String>> commitIds);
+}

--- a/src/main/java/pl/net/was/trino/git/TagsRecordCursor.java
+++ b/src/main/java/pl/net/was/trino/git/TagsRecordCursor.java
@@ -23,7 +23,6 @@ import org.eclipse.jgit.lib.Ref;
 
 import java.util.Iterator;
 import java.util.List;
-import java.util.Optional;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
@@ -38,7 +37,7 @@ public class TagsRecordCursor
 
     private List<String> fields;
 
-    public TagsRecordCursor(List<GitColumnHandle> columnHandles, Git repo, Optional<List<String>> commitIds)
+    public TagsRecordCursor(List<GitColumnHandle> columnHandles, Git repo)
     {
         this.columnHandles = columnHandles;
 

--- a/src/main/java/pl/net/was/trino/git/TagsRecordCursor.java
+++ b/src/main/java/pl/net/was/trino/git/TagsRecordCursor.java
@@ -32,7 +32,8 @@ import java.util.List;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
-import static java.lang.Math.multiplyExact;
+import static io.trino.spi.type.DateTimeEncoding.packDateTimeWithZone;
+import static io.trino.spi.type.TimeZoneKey.getTimeZoneKey;
 import static java.util.Arrays.asList;
 
 public class TagsRecordCursor
@@ -112,7 +113,7 @@ public class TagsRecordCursor
                 throw new UncheckedIOException(e);
             }
             if (annotated) {
-                tagTime = multiplyExact(revTag.getTaggerIdent().getWhenAsInstant().toEpochMilli(), 1_000);
+                tagTime = packDateTimeWithZone(revTag.getTaggerIdent().getWhenAsInstant().toEpochMilli(), getTimeZoneKey(revTag.getTaggerIdent().getZoneId().getId()));
             }
         }
 

--- a/src/test/java/pl/net/was/trino/git/TestGitClient.java
+++ b/src/test/java/pl/net/was/trino/git/TestGitClient.java
@@ -15,9 +15,11 @@ package pl.net.was.trino.git;
 
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.errors.GitAPIException;
+import org.eclipse.jgit.errors.ConfigInvalidException;
 import org.eclipse.jgit.lib.PersonIdent;
 import org.eclipse.jgit.lib.Repository;
 import org.eclipse.jgit.storage.file.FileRepositoryBuilder;
+import org.eclipse.jgit.util.SystemReader;
 import org.junit.jupiter.api.Test;
 
 import java.io.File;
@@ -45,6 +47,14 @@ public class TestGitClient
     public static void setupRepo(URI uri)
             throws IOException, GitAPIException
     {
+        // make sure the global Git config is not being used
+        try {
+            SystemReader.getInstance().getUserConfig().clear();
+        }
+        catch (ConfigInvalidException e) {
+            // ignore
+        }
+
         // ensure the repo dir exists, remove and recreate if necessary
         File localPath;
         try {

--- a/src/test/java/pl/net/was/trino/git/TestGitClient.java
+++ b/src/test/java/pl/net/was/trino/git/TestGitClient.java
@@ -26,13 +26,12 @@ import java.io.File;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.net.URI;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.Comparator;
 import java.util.Date;
 import java.util.Set;
 import java.util.TimeZone;
 
+import static com.google.common.io.MoreFiles.deleteRecursively;
+import static com.google.common.io.RecursiveDeleteOption.ALLOW_INSECURE;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestGitClient
@@ -64,10 +63,7 @@ public class TestGitClient
             return;
         }
         if (localPath.exists()) {
-            Files.walk(localPath.toPath())
-                    .sorted(Comparator.reverseOrder())
-                    .map(Path::toFile)
-                    .forEach(File::delete);
+            deleteRecursively(localPath.toPath(), ALLOW_INSECURE);
         }
 
         Repository repository = FileRepositoryBuilder.create(new File(localPath, ".git"));

--- a/src/test/java/pl/net/was/trino/git/TestGitClient.java
+++ b/src/test/java/pl/net/was/trino/git/TestGitClient.java
@@ -105,6 +105,11 @@ public class TestGitClient
                 .setTagger(author)
                 .call();
 
+        git.tag()
+                .setName("unannotated_tag_for_testing")
+                .setAnnotated(false)
+                .call();
+
         // ensure all loose objects are packed
         git.gc().call();
     }

--- a/src/test/java/pl/net/was/trino/git/TestGitClient.java
+++ b/src/test/java/pl/net/was/trino/git/TestGitClient.java
@@ -26,12 +26,12 @@ import java.io.File;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.net.URI;
-import java.util.Date;
+import java.time.Instant;
 import java.util.Set;
-import java.util.TimeZone;
 
 import static com.google.common.io.MoreFiles.deleteRecursively;
 import static com.google.common.io.RecursiveDeleteOption.ALLOW_INSECURE;
+import static java.time.ZoneOffset.UTC;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestGitClient
@@ -75,7 +75,7 @@ public class TestGitClient
             throw new IOException("Could not create file " + myFile);
         }
 
-        PersonIdent author = new PersonIdent("test", "test@invalid.com", new Date(1580897313000L), TimeZone.getTimeZone("UTC"));
+        PersonIdent author = new PersonIdent("test", "test@invalid.com", Instant.ofEpochSecond(1580897313L), UTC);
         // commit the new file
         Git git = new Git(repository);
         git.add().addFilepattern(".").call();

--- a/src/test/java/pl/net/was/trino/git/TestGitRecordSet.java
+++ b/src/test/java/pl/net/was/trino/git/TestGitRecordSet.java
@@ -31,6 +31,7 @@ import java.util.Optional;
 import java.util.OptionalLong;
 
 import static io.trino.spi.type.VarcharType.createUnboundedVarcharType;
+import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class TestGitRecordSet
@@ -134,7 +135,9 @@ public class TestGitRecordSet
                 assertThat(cursor.isNull(1)).isFalse();
                 data.put(cursor.getSlice(0).toStringUtf8(), cursor.getSlice(1).toStringUtf8());
             }
-            assertThat(data).isEqualTo(Map.of("7afcc1aaeab61c3fd7f2b1b5df5178a823cbf77e", "refs/tags/tag_for_testing"));
+            assertThat(data).isEqualTo(Map.of(
+                    "7afcc1aaeab61c3fd7f2b1b5df5178a823cbf77e", "refs/tags/tag_for_testing",
+                    "c3b14e59f88d0d6597b98ee93cf61e7556d540a4", "refs/tags/unannotated_tag_for_testing"));
         }
     }
 
@@ -156,12 +159,13 @@ public class TestGitRecordSet
             while (cursor.advanceNextPosition()) {
                 assertThat(cursor.isNull(0)).isFalse();
                 assertThat(cursor.isNull(1)).isFalse();
-                assertThat(cursor.isNull(2)).isFalse();
-                data.put(cursor.getSlice(0).toStringUtf8(), List.of(
+                data.put(cursor.getSlice(0).toStringUtf8(), asList(
                         cursor.getSlice(1).toStringUtf8(),
-                        cursor.getLong(2)));
+                        cursor.isNull(2) ? null : cursor.getLong(2)));
             }
-            assertThat(data).isEqualTo(Map.of("7afcc1aaeab61c3fd7f2b1b5df5178a823cbf77e", List.of("refs/tags/tag_for_testing", 1580897313000000L)));
+            assertThat(data).isEqualTo(Map.of(
+                    "7afcc1aaeab61c3fd7f2b1b5df5178a823cbf77e", asList("refs/tags/tag_for_testing", 1580897313000000L),
+                    "c3b14e59f88d0d6597b98ee93cf61e7556d540a4", asList("refs/tags/unannotated_tag_for_testing", null)));
         }
     }
 

--- a/src/test/java/pl/net/was/trino/git/TestGitRecordSet.java
+++ b/src/test/java/pl/net/was/trino/git/TestGitRecordSet.java
@@ -164,7 +164,7 @@ public class TestGitRecordSet
                         cursor.isNull(2) ? null : cursor.getLong(2)));
             }
             assertThat(data).isEqualTo(Map.of(
-                    "7afcc1aaeab61c3fd7f2b1b5df5178a823cbf77e", asList("refs/tags/tag_for_testing", 1580897313000000L),
+                    "7afcc1aaeab61c3fd7f2b1b5df5178a823cbf77e", asList("refs/tags/tag_for_testing", 6475355394048000L),
                     "c3b14e59f88d0d6597b98ee93cf61e7556d540a4", asList("refs/tags/unannotated_tag_for_testing", null)));
         }
     }

--- a/src/test/java/pl/net/was/trino/git/TestGitRecordSet.java
+++ b/src/test/java/pl/net/was/trino/git/TestGitRecordSet.java
@@ -78,20 +78,20 @@ public class TestGitRecordSet
                 new GitColumnHandle("object_id", createUnboundedVarcharType(), 0),
                 new GitColumnHandle("author_name", createUnboundedVarcharType(), 1),
                 new GitColumnHandle("commit_time", TimestampWithTimeZoneType.TIMESTAMP_TZ_SECONDS, 2)));
-        RecordCursor cursor = recordSet.cursor();
+        try (RecordCursor cursor = recordSet.cursor()) {
+            assertThat(cursor.getType(0)).isEqualTo(createUnboundedVarcharType());
+            assertThat(cursor.getType(1)).isEqualTo(createUnboundedVarcharType());
 
-        assertThat(cursor.getType(0)).isEqualTo(createUnboundedVarcharType());
-        assertThat(cursor.getType(1)).isEqualTo(createUnboundedVarcharType());
-
-        Map<String, List<Object>> data = new LinkedHashMap<>();
-        while (cursor.advanceNextPosition()) {
-            data.put(cursor.getSlice(0).toStringUtf8(), List.of(
-                    cursor.getSlice(1).toStringUtf8(),
-                    cursor.getLong(2)));
+            Map<String, List<Object>> data = new LinkedHashMap<>();
+            while (cursor.advanceNextPosition()) {
+                data.put(cursor.getSlice(0).toStringUtf8(), List.of(
+                        cursor.getSlice(1).toStringUtf8(),
+                        cursor.getLong(2)));
+            }
+            assertThat(data).isEqualTo(Map.of(
+                    "080dfdf0aac7d302dc31d57f62942bb6533944f7", List.of("test", 6475355394048000L),
+                    "c3b14e59f88d0d6597b98ee93cf61e7556d540a4", List.of("test", 6475355394048000L)));
         }
-        assertThat(data).isEqualTo(Map.of(
-                "080dfdf0aac7d302dc31d57f62942bb6533944f7", List.of("test", 6475355394048000L),
-                "c3b14e59f88d0d6597b98ee93cf61e7556d540a4", List.of("test", 6475355394048000L)));
     }
 
     @Test
@@ -102,18 +102,18 @@ public class TestGitRecordSet
         RecordSet recordSet = new GitRecordSet(split, table, List.of(
                 new GitColumnHandle("object_id", createUnboundedVarcharType(), 0),
                 new GitColumnHandle("name", createUnboundedVarcharType(), 1)));
-        RecordCursor cursor = recordSet.cursor();
+        try (RecordCursor cursor = recordSet.cursor()) {
+            assertThat(cursor.getType(0)).isEqualTo(createUnboundedVarcharType());
+            assertThat(cursor.getType(1)).isEqualTo(createUnboundedVarcharType());
 
-        assertThat(cursor.getType(0)).isEqualTo(createUnboundedVarcharType());
-        assertThat(cursor.getType(1)).isEqualTo(createUnboundedVarcharType());
-
-        Map<String, String> data = new LinkedHashMap<>();
-        while (cursor.advanceNextPosition()) {
-            assertThat(cursor.isNull(0)).isFalse();
-            assertThat(cursor.isNull(1)).isFalse();
-            data.put(cursor.getSlice(0).toStringUtf8(), cursor.getSlice(1).toStringUtf8());
+            Map<String, String> data = new LinkedHashMap<>();
+            while (cursor.advanceNextPosition()) {
+                assertThat(cursor.isNull(0)).isFalse();
+                assertThat(cursor.isNull(1)).isFalse();
+                data.put(cursor.getSlice(0).toStringUtf8(), cursor.getSlice(1).toStringUtf8());
+            }
+            assertThat(data).isEqualTo(Map.of("c3b14e59f88d0d6597b98ee93cf61e7556d540a4", "refs/heads/master"));
         }
-        assertThat(data).isEqualTo(Map.of("c3b14e59f88d0d6597b98ee93cf61e7556d540a4", "refs/heads/master"));
     }
 
     @Test
@@ -124,18 +124,18 @@ public class TestGitRecordSet
         RecordSet recordSet = new GitRecordSet(split, table, List.of(
                 new GitColumnHandle("object_id", createUnboundedVarcharType(), 0),
                 new GitColumnHandle("name", createUnboundedVarcharType(), 1)));
-        RecordCursor cursor = recordSet.cursor();
+        try (RecordCursor cursor = recordSet.cursor()) {
+            assertThat(cursor.getType(0)).isEqualTo(createUnboundedVarcharType());
+            assertThat(cursor.getType(1)).isEqualTo(createUnboundedVarcharType());
 
-        assertThat(cursor.getType(0)).isEqualTo(createUnboundedVarcharType());
-        assertThat(cursor.getType(1)).isEqualTo(createUnboundedVarcharType());
-
-        Map<String, String> data = new LinkedHashMap<>();
-        while (cursor.advanceNextPosition()) {
-            assertThat(cursor.isNull(0)).isFalse();
-            assertThat(cursor.isNull(1)).isFalse();
-            data.put(cursor.getSlice(0).toStringUtf8(), cursor.getSlice(1).toStringUtf8());
+            Map<String, String> data = new LinkedHashMap<>();
+            while (cursor.advanceNextPosition()) {
+                assertThat(cursor.isNull(0)).isFalse();
+                assertThat(cursor.isNull(1)).isFalse();
+                data.put(cursor.getSlice(0).toStringUtf8(), cursor.getSlice(1).toStringUtf8());
+            }
+            assertThat(data).isEqualTo(Map.of("7afcc1aaeab61c3fd7f2b1b5df5178a823cbf77e", "refs/tags/tag_for_testing"));
         }
-        assertThat(data).isEqualTo(Map.of("7afcc1aaeab61c3fd7f2b1b5df5178a823cbf77e", "refs/tags/tag_for_testing"));
     }
 
     @Test
@@ -146,20 +146,20 @@ public class TestGitRecordSet
         RecordSet recordSet = new GitRecordSet(split, table, List.of(
                 new GitColumnHandle("commit_id", createUnboundedVarcharType(), 0),
                 new GitColumnHandle("object_id", createUnboundedVarcharType(), 1)));
-        RecordCursor cursor = recordSet.cursor();
+        try (RecordCursor cursor = recordSet.cursor()) {
+            assertThat(cursor.getType(0)).isEqualTo(createUnboundedVarcharType());
+            assertThat(cursor.getType(1)).isEqualTo(createUnboundedVarcharType());
 
-        assertThat(cursor.getType(0)).isEqualTo(createUnboundedVarcharType());
-        assertThat(cursor.getType(1)).isEqualTo(createUnboundedVarcharType());
-
-        Map<String, String> data = new LinkedHashMap<>();
-        while (cursor.advanceNextPosition()) {
-            assertThat(cursor.isNull(0)).isFalse();
-            assertThat(cursor.isNull(1)).isFalse();
-            data.put(cursor.getSlice(0).toStringUtf8(), cursor.getSlice(1).toStringUtf8());
+            Map<String, String> data = new LinkedHashMap<>();
+            while (cursor.advanceNextPosition()) {
+                assertThat(cursor.isNull(0)).isFalse();
+                assertThat(cursor.isNull(1)).isFalse();
+                data.put(cursor.getSlice(0).toStringUtf8(), cursor.getSlice(1).toStringUtf8());
+            }
+            assertThat(data).isEqualTo(Map.of(
+                    "080dfdf0aac7d302dc31d57f62942bb6533944f7", "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391",
+                    "c3b14e59f88d0d6597b98ee93cf61e7556d540a4", "5dd01c177f5d7d1be5346a5bc18a569a7410c2ef"));
         }
-        assertThat(data).isEqualTo(Map.of(
-                "080dfdf0aac7d302dc31d57f62942bb6533944f7", "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391",
-                "c3b14e59f88d0d6597b98ee93cf61e7556d540a4", "5dd01c177f5d7d1be5346a5bc18a569a7410c2ef"));
     }
 
     @Test
@@ -170,22 +170,22 @@ public class TestGitRecordSet
         RecordSet recordSet = new GitRecordSet(split, table, List.of(
                 new GitColumnHandle("object_id", createUnboundedVarcharType(), 0),
                 new GitColumnHandle("contents", VarbinaryType.VARBINARY, 1)));
-        RecordCursor cursor = recordSet.cursor();
+        try (RecordCursor cursor = recordSet.cursor()) {
+            assertThat(cursor.getType(0)).isEqualTo(createUnboundedVarcharType());
+            assertThat(cursor.getType(1)).isEqualTo(VarbinaryType.VARBINARY);
 
-        assertThat(cursor.getType(0)).isEqualTo(createUnboundedVarcharType());
-        assertThat(cursor.getType(1)).isEqualTo(VarbinaryType.VARBINARY);
-
-        Map<String, String> data = new LinkedHashMap<>();
-        while (cursor.advanceNextPosition()) {
-            assertThat(cursor.isNull(0)).isFalse();
-            assertThat(cursor.isNull(1)).isFalse();
-            String objectId = cursor.getSlice(0).toStringUtf8();
-            String contents = cursor.getSlice(1).toStringUtf8();
-            data.put(objectId, contents);
+            Map<String, String> data = new LinkedHashMap<>();
+            while (cursor.advanceNextPosition()) {
+                assertThat(cursor.isNull(0)).isFalse();
+                assertThat(cursor.isNull(1)).isFalse();
+                String objectId = cursor.getSlice(0).toStringUtf8();
+                String contents = cursor.getSlice(1).toStringUtf8();
+                data.put(objectId, contents);
+            }
+            assertThat(data).isEqualTo(Map.of(
+                    "5dd01c177f5d7d1be5346a5bc18a569a7410c2ef", "Hello, world!",
+                    "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391", ""));
         }
-        assertThat(data).isEqualTo(Map.of(
-                "5dd01c177f5d7d1be5346a5bc18a569a7410c2ef", "Hello, world!",
-                "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391", ""));
     }
 
     @Test
@@ -198,31 +198,31 @@ public class TestGitRecordSet
                 new GitColumnHandle("old_commit_id", createUnboundedVarcharType(), 1),
                 new GitColumnHandle("added_lines", IntegerType.INTEGER, 2),
                 new GitColumnHandle("deleted_lines", IntegerType.INTEGER, 3)));
-        RecordCursor cursor = recordSet.cursor();
+        try (RecordCursor cursor = recordSet.cursor()) {
+            assertThat(cursor.getType(0)).isEqualTo(createUnboundedVarcharType());
+            assertThat(cursor.getType(1)).isEqualTo(createUnboundedVarcharType());
+            assertThat(cursor.getType(2)).isEqualTo(IntegerType.INTEGER);
+            assertThat(cursor.getType(3)).isEqualTo(IntegerType.INTEGER);
 
-        assertThat(cursor.getType(0)).isEqualTo(createUnboundedVarcharType());
-        assertThat(cursor.getType(1)).isEqualTo(createUnboundedVarcharType());
-        assertThat(cursor.getType(2)).isEqualTo(IntegerType.INTEGER);
-        assertThat(cursor.getType(3)).isEqualTo(IntegerType.INTEGER);
-
-        Map<String, List<Object>> data = new LinkedHashMap<>();
-        while (cursor.advanceNextPosition()) {
-            assertThat(cursor.isNull(0)).isFalse();
-            assertThat(cursor.isNull(1)).isFalse();
-            assertThat(cursor.isNull(2)).isFalse();
-            assertThat(cursor.isNull(3)).isFalse();
-            data.put(
-                    cursor.getSlice(0).toStringUtf8(),
+            Map<String, List<Object>> data = new LinkedHashMap<>();
+            while (cursor.advanceNextPosition()) {
+                assertThat(cursor.isNull(0)).isFalse();
+                assertThat(cursor.isNull(1)).isFalse();
+                assertThat(cursor.isNull(2)).isFalse();
+                assertThat(cursor.isNull(3)).isFalse();
+                data.put(
+                        cursor.getSlice(0).toStringUtf8(),
+                        List.of(
+                                cursor.getSlice(1).toStringUtf8(),
+                                cursor.getLong(2),
+                                cursor.getLong(3)));
+            }
+            assertThat(data).isEqualTo(Map.of(
+                    "c3b14e59f88d0d6597b98ee93cf61e7556d540a4",
                     List.of(
-                            cursor.getSlice(1).toStringUtf8(),
-                            cursor.getLong(2),
-                            cursor.getLong(3)));
+                            "080dfdf0aac7d302dc31d57f62942bb6533944f7",
+                            1L,
+                            0L)));
         }
-        assertThat(data).isEqualTo(Map.of(
-                "c3b14e59f88d0d6597b98ee93cf61e7556d540a4",
-                List.of(
-                        "080dfdf0aac7d302dc31d57f62942bb6533944f7",
-                        1L,
-                        0L)));
     }
 }


### PR DESCRIPTION
Use secure hash for determining path for local checkout.